### PR TITLE
BAP-20722: RMQ messages should not contain their processor name as a property

### DIFF
--- a/src/Oro/Bundle/MagentoBundle/OroMagentoBundle.php
+++ b/src/Oro/Bundle/MagentoBundle/OroMagentoBundle.php
@@ -2,9 +2,7 @@
 
 namespace Oro\Bundle\MagentoBundle;
 
-use Oro\Bundle\MagentoBundle\Async\Topics;
 use Oro\Bundle\MagentoBundle\DependencyInjection\Compiler\ExcludeDictionaryEntitiesFromRestApiPass;
-use Oro\Bundle\MessageQueueBundle\DependencyInjection\Compiler\AddTopicMetaPass;
 use Oro\Component\DependencyInjection\Compiler\PriorityTaggedLocatorCompilerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -25,11 +23,5 @@ class OroMagentoBundle extends Bundle
             'type'
         ));
         $container->addCompilerPass(new ExcludeDictionaryEntitiesFromRestApiPass());
-
-        $container->addCompilerPass(
-            AddTopicMetaPass::create()
-                ->add(Topics::SYNC_CART_EXPIRATION_INTEGRATION)
-                ->add(Topics::SYNC_INITIAL_INTEGRATION)
-        );
     }
 }


### PR DESCRIPTION
- removed useless AddTopicMetaPass